### PR TITLE
Remove duplicate code between SpellingParser and SpellChecker

### DIFF
--- a/SpellChecker/src/main/java/org/fife/com/swabunga/spell/engine/DoubleMeta.java
+++ b/SpellChecker/src/main/java/org/fife/com/swabunga/spell/engine/DoubleMeta.java
@@ -47,7 +47,7 @@ public class DoubleMeta implements Transformator {
 
   /**
    * Used in the getSuggestions method.
-   * All of the letters in the misspelled word are replaced with the characters from
+   * All the letters in the misspelled word are replaced with the characters from
    * this list to try and generate more suggestions, which implies l*n tries,
    * if l is the size of the string, and n is the size of this list.
    * <p>

--- a/SpellChecker/src/main/java/org/fife/com/swabunga/spell/engine/SpellDictionaryASpell.java
+++ b/SpellChecker/src/main/java/org/fife/com/swabunga/spell/engine/SpellDictionaryASpell.java
@@ -140,9 +140,6 @@ public abstract class SpellDictionaryASpell implements SpellDictionary {
   @Override
   public List<Word> getSuggestions(String word, int threshold, int[][] matrix) {
 
-  	int i;
-  	int j;
-
   	if (matrix == null) {
         matrix = new int[0][0];
     }
@@ -158,18 +155,15 @@ public abstract class SpellDictionaryASpell implements SpellDictionary {
     //interchange
     nearmisscodes = new HashMap<>();
     char[] charArray = word.toCharArray();
-    char a;
-    char b ;
 
-    for (i = 0; i < word.length() - 1; i++) {
-      a = charArray[i];
-      b = charArray[i + 1];
-      charArray[i] = b;
-      charArray[i + 1] = a;
+    for (int i = 0; i < word.length() - 1; i++) {
+      char temp = charArray[i];
+      charArray[i] = charArray[i + 1];
+      charArray[i + 1] = temp;
       String s = getCode(new String(charArray));
       nearmisscodes.put(s, s);
-      charArray[i] = a;
-      charArray[i + 1] = b;
+      charArray[i + 1] = charArray[i];
+      charArray[i] = temp;
     }
 
     char[] replacelist = tf.getReplaceList();
@@ -177,9 +171,9 @@ public abstract class SpellDictionaryASpell implements SpellDictionary {
     //change
     charArray = word.toCharArray();
     char original;
-    for (i = 0; i < word.length(); i++) {
+    for (int i = 0; i < word.length(); i++) {
       original = charArray[i];
-      for (j = 0; j < replacelist.length; j++) {
+      for (int j = 0; j < replacelist.length; j++) {
         charArray[i] = replacelist[j];
         String s = getCode(new String(charArray));
         nearmisscodes.put(s, s);
@@ -191,7 +185,7 @@ public abstract class SpellDictionaryASpell implements SpellDictionary {
     charArray = (word += " ").toCharArray();
     int iy = charArray.length - 1;
     while (true) {
-      for (j = 0; j < replacelist.length; j++) {
+      for (int j = 0; j < replacelist.length; j++) {
         charArray[iy] = replacelist[j];
         String s = getCode(new String(charArray));
         nearmisscodes.put(s, s);
@@ -208,14 +202,14 @@ public abstract class SpellDictionaryASpell implements SpellDictionary {
     char[] charArray2 = new char[charArray.length - 1];
     System.arraycopy(charArray, 0, charArray2, 0, charArray2.length);
 
-    a = charArray[charArray.length - 1];
+    char a = charArray[charArray.length - 1];
     int ii = charArray2.length;
     while (true) {
       String s = getCode(new String(charArray));
       nearmisscodes.put(s, s);
       if (ii == 0)
         break;
-      b = a;
+      char b = a;
       a = charArray2[ii - 1];
       charArray2[ii - 1] = b;
       --ii;

--- a/SpellChecker/src/main/java/org/fife/com/swabunga/spell/engine/Transformator.java
+++ b/SpellChecker/src/main/java/org/fife/com/swabunga/spell/engine/Transformator.java
@@ -39,11 +39,11 @@ public interface Transformator {
   /**
    * gets the list of characters that should be swapped in to the misspelled word
    * in order to try to find more suggestions.
-   * In general, this list represents all of the unique phonetic characters
+   * In general, this list represents all the unique phonetic characters
    * for this Transformator.
    * <p/>
    * The replace list is used in the getSuggestions method.
-   * All of the letters in the misspelled word are replaced with the characters from
+   * All the letters in the misspelled word are replaced with the characters from
    * this list to try and generate more suggestions, which implies l*n tries,
    * if l is the size of the string, and n is the size of this list.
    * <p/>

--- a/SpellChecker/src/main/java/org/fife/com/swabunga/spell/event/BasicSpellCheckEvent.java
+++ b/SpellChecker/src/main/java/org/fife/com/swabunga/spell/event/BasicSpellCheckEvent.java
@@ -19,32 +19,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 package org.fife.com.swabunga.spell.event;
 
-import java.util.List;
-
 /**
  * This event is fired off by the SpellChecker and is passed to the
- * registered SpellCheckListeners.
+ * registered SpellCheckListeners. Modified to only be incorrect words
+ * and their locations for RSTA's usage patterns.
  *
  * @author Jason Height (jheight@chariot.net.au)
  */
 class BasicSpellCheckEvent implements SpellCheckEvent {
 
   /**
-   * The list holding the suggested Word objects for the misspelled word.
-   */
-  private List<Word> suggestions;
-  /**
    * The misspelled word.
    */
   private String invalidWord;
-  /**
-   * The action to be done when the event returns.
-   */
-  private short action = INITIAL;
-  /**
-   * Contains the word to be replaced if the action is REPLACE or REPLACEALL.
-   */
-  private String replaceWord;
 
   private int startPosition;
 
@@ -53,34 +40,21 @@ class BasicSpellCheckEvent implements SpellCheckEvent {
    * Constructs the SpellCheckEvent.
    *
    * @param invalidWord The word that is misspelled
-   * @param suggestions A list of Word objects that are suggested to replace the currently misspelled word
    * @param tokenizer   The reference to the tokenizer that caused this event to fire.
    */
-  BasicSpellCheckEvent(String invalidWord, List<Word> suggestions, WordTokenizer tokenizer) {
-    this(invalidWord, suggestions, tokenizer.getCurrentWordPosition());
+  BasicSpellCheckEvent(String invalidWord, WordTokenizer tokenizer) {
+    this(invalidWord, tokenizer.getCurrentWordPosition());
   }
 
   /**
    * Constructs the SpellCheckEvent.
    *
    * @param invalidWord   The word that is misspelled
-   * @param suggestions   A list of Word objects that are suggested to replace the currently misspelled word
    * @param startPosition The position of the misspelled word.
    */
-  BasicSpellCheckEvent(String invalidWord, List<Word> suggestions, int startPosition) {
+  BasicSpellCheckEvent(String invalidWord, int startPosition) {
     this.invalidWord = invalidWord;
-    this.suggestions = suggestions;
     this.startPosition = startPosition;
-  }
-
-  /**
-   * Returns the list of suggested Word objects.
-   *
-   * @return A list of words phonetically close to the misspelled word
-   */
-  @Override
-  public List<Word> getSuggestions() {
-    return suggestions;
   }
 
   /**
@@ -112,83 +86,5 @@ class BasicSpellCheckEvent implements SpellCheckEvent {
   @Override
   public int getWordContextPosition() {
     return startPosition;
-  }
-
-  /**
-   * Returns the action type the user has to handle.
-   *
-   * @return The type of action the event is carrying.
-   */
-  @Override
-  public short getAction() {
-    return action;
-  }
-
-  /**
-   * Returns the text to replace.
-   *
-   * @return the text of the word to replace
-   */
-  @Override
-  public String getReplaceWord() {
-    return replaceWord;
-  }
-
-  /**
-   * Set the action to replace the currently misspelled word with the new word.
-   *
-   * @param newWord  The word to replace the currently misspelled word
-   * @param replaceAll If set to true, the SpellChecker will replace all
-   *           further occurrences of the misspelled word without firing a SpellCheckEvent.
-   */
-  @Override
-  public void replaceWord(String newWord, boolean replaceAll) {
-    if (action != INITIAL)
-      throw new IllegalStateException("The action can can only be set once");
-    if (replaceAll)
-      action = REPLACEALL;
-    else
-      action = REPLACE;
-    replaceWord = newWord;
-  }
-
-  /**
-   * Set the action it ignore the currently misspelled word.
-   *
-   * @param ignoreAll If set to true, the SpellChecker will replace all
-   *          further occurrences of the misspelled word without firing a SpellCheckEvent.
-   */
-  @Override
-  public void ignoreWord(boolean ignoreAll) {
-    if (action != INITIAL)
-      throw new IllegalStateException("The action can can only be set once");
-    if (ignoreAll)
-      action = IGNOREALL;
-    else
-      action = IGNORE;
-  }
-
-  /**
-   * Set the action to add a new word into the dictionary. This will also replace the
-   * currently misspelled word.
-   *
-   * @param newWord The new word to add to the dictionary.
-   */
-  @Override
-  public void addToDictionary(String newWord) {
-    if (action != INITIAL)
-      throw new IllegalStateException("The action can can only be set once");
-    action = ADDTODICT;
-    replaceWord = newWord;
-  }
-
-  /**
-   * Set the action to terminate processing of the spellchecker.
-   */
-  @Override
-  public void cancel() {
-    if (action != INITIAL)
-      throw new IllegalStateException("The action can can only be set once");
-    action = CANCEL;
   }
 }

--- a/SpellChecker/src/main/java/org/fife/com/swabunga/spell/event/SpellCheckEvent.java
+++ b/SpellChecker/src/main/java/org/fife/com/swabunga/spell/event/SpellCheckEvent.java
@@ -19,8 +19,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 package org.fife.com.swabunga.spell.event;
 
-import java.util.List;
-
 /**
  * This event is fired off by the SpellChecker and is passed to the
  * registered SpellCheckListeners
@@ -32,41 +30,6 @@ import java.util.List;
  * @author Jason Height (jheight@chariot.net.au)
  */
 public interface SpellCheckEvent {
-  /**
-   * Field indicating that the incorrect word should be ignored.
-   */
-  short IGNORE = 0;
-  /**
-   * Field indicating that the incorrect word should be ignored forever.
-   */
-  short IGNOREALL = 1;
-  /**
-   * Field indicating that the incorrect word should be replaced.
-   */
-  short REPLACE = 2;
-  /**
-   * Field indicating that the incorrect word should be replaced always.
-   */
-  short REPLACEALL = 3;
-  /**
-   * Field indicating that the incorrect word should be added to the dictionary.
-   */
-  short ADDTODICT = 4;
-  /**
-   * Field indicating that the spell checking should be terminated.
-   */
-  short CANCEL = 5;
-  /**
-   * Initial case for the action.
-   */
-  short INITIAL = -1;
-
-  /**
-   * Returns the list of suggested Word objects.
-   *
-   * @return A list of words phonetically close to the misspelled word
-   */
-  List<Word> getSuggestions();
 
   /**
    * Returns the currently misspelled word.
@@ -88,48 +51,4 @@ public interface SpellCheckEvent {
    * @return The position of the word
    */
   int getWordContextPosition();
-
-  /**
-   * Returns the action type the user has to handle.
-   *
-   * @return The type of action the event is carrying
-   */
-  short getAction();
-
-  /**
-   * Returns the text to replace.
-   *
-   * @return the text of the word to replace
-   */
-  String getReplaceWord();
-
-  /**
-   * Set the action to replace the currently misspelled word with the new word.
-   *
-   * @param newWord  The word to replace the currently misspelled word
-   * @param replaceAll If set to true, the SpellChecker will replace all
-   *           further occurrences of the misspelled word without firing a SpellCheckEvent.
-   */
-  void replaceWord(String newWord, boolean replaceAll);
-
-  /**
-   * Set the action it ignore the currently misspelled word.
-   *
-   * @param ignoreAll If set to true, the SpellChecker will replace all
-   *          further occurrences of the misspelled word without firing a SpellCheckEvent.
-   */
-  void ignoreWord(boolean ignoreAll);
-
-  /**
-   * Set the action to add a new word into the dictionary. This will also replace the
-   * currently misspelled word.
-   *
-   * @param newWord The new word to add
-   */
-  void addToDictionary(String newWord);
-
-  /**
-   * Set the action to terminate processing of the spell checker.
-   */
-  void cancel();
 }

--- a/SpellChecker/src/main/java/org/fife/com/swabunga/spell/event/SpellCheckListener.java
+++ b/SpellChecker/src/main/java/org/fife/com/swabunga/spell/event/SpellCheckListener.java
@@ -32,6 +32,7 @@ public interface SpellCheckListener extends EventListener {
    * Propagates the spelling errors to listeners.
    *
    * @param event The event to handle.
+   * @return Whether to cancel the rest of the spell check.
    */
-  void spellingError(SpellCheckEvent event);
+  boolean spellingError(SpellCheckEvent event);
 }

--- a/SpellChecker/src/test/java/org/fife/com/swabunga/spell/event/BasicSpellCheckEventTest.java
+++ b/SpellChecker/src/test/java/org/fife/com/swabunga/spell/event/BasicSpellCheckEventTest.java
@@ -3,9 +3,6 @@ package org.fife.com.swabunga.spell.event;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.List;
-
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -14,14 +11,12 @@ import static org.junit.jupiter.api.Assertions.*;
 class BasicSpellCheckEventTest {
 
     private BasicSpellCheckEvent event;
-    private List<Word> suggestions;
     private String invalidWord;
 
     @BeforeEach
     void setUp() {
         invalidWord = "mispelled";
-        suggestions = Collections.singletonList(new Word("misspelled", 0));
-        event = new BasicSpellCheckEvent(invalidWord, suggestions, 0);
+        event = new BasicSpellCheckEvent(invalidWord, 0);
     }
 
     @Test
@@ -29,13 +24,8 @@ class BasicSpellCheckEventTest {
         assertDoesNotThrow(() -> {
             StringWordTokenizer tokenizer = new StringWordTokenizer("This");
             tokenizer.nextWord();
-            new BasicSpellCheckEvent(invalidWord, suggestions, tokenizer);
+            new BasicSpellCheckEvent(invalidWord, tokenizer);
         });
-    }
-
-    @Test
-    void testGetSuggestions() {
-        assertEquals(suggestions, event.getSuggestions());
     }
 
     @Test
@@ -51,74 +41,5 @@ class BasicSpellCheckEventTest {
     @Test
     void testGetWordContextPosition() {
         assertEquals(0, event.getWordContextPosition());
-    }
-
-    @Test
-    void testGetAction_initial() {
-        assertEquals(BasicSpellCheckEvent.INITIAL, event.getAction());
-    }
-
-    @Test
-    void testReplaceWord() {
-        event.replaceWord("corrected", false);
-        assertEquals(BasicSpellCheckEvent.REPLACE, event.getAction());
-        assertEquals("corrected", event.getReplaceWord());
-    }
-
-    @Test
-    void testReplaceWord_replaceAll() {
-        event.replaceWord("corrected", true);
-        assertEquals(BasicSpellCheckEvent.REPLACEALL, event.getAction());
-        assertEquals("corrected", event.getReplaceWord());
-    }
-
-    @Test
-    void testReplaceWord_actionCanOnlyBeSetOnce() {
-        event.replaceWord("corrected", false);
-        assertEquals(BasicSpellCheckEvent.REPLACE, event.getAction());
-        assertThrows(IllegalStateException.class, () -> event.replaceWord("corrected", true));
-    }
-
-    @Test
-    void testIgnoreWord() {
-        event.ignoreWord(false);
-        assertEquals(BasicSpellCheckEvent.IGNORE, event.getAction());
-    }
-
-    @Test
-    void testIgnoreWord_ignoreAll() {
-        event.ignoreWord(true);
-        assertEquals(BasicSpellCheckEvent.IGNOREALL, event.getAction());
-    }
-
-    @Test
-    void testIgnoreWord_actionCanOnlyBeSetOnce() {
-        event.replaceWord("corrected", false);
-        assertThrows(IllegalStateException.class, () -> event.ignoreWord(false));
-    }
-
-    @Test
-    void testAddToDictionary() {
-        event.addToDictionary("newword");
-        assertEquals(BasicSpellCheckEvent.ADDTODICT, event.getAction());
-        assertEquals("newword", event.getReplaceWord());
-    }
-
-    @Test
-    void testAddToDictionary_actionCanOnlyBeSetOnce() {
-        event.addToDictionary("newword");
-        assertThrows(IllegalStateException.class, () -> event.addToDictionary("newword"));
-    }
-
-    @Test
-    void testCancel() {
-        event.cancel();
-        assertEquals(BasicSpellCheckEvent.CANCEL, event.getAction());
-    }
-
-    @Test
-    void testCancel_actionCanOnlyBeSetOnce() {
-        event.cancel();
-        assertThrows(IllegalStateException.class, () -> event.cancel());
     }
 }


### PR DESCRIPTION
There's a lot of dupliate code between `SpellChecker` (ships with Jazzy) and `SpellingParser` (an RSTA `Parser` implementation that delegates to `SpellChecker` to aggregate misspelled words). Specifically, both have mechanisms to replace words, ignore words, etc.

We should remove the duplicate code, and make `SpellingParser` the driver for such operations. `SpellChecker` becomes a thin interface over Jazzy, perhaps even allowing for other spelling library implementations, even though we'll never have another one.